### PR TITLE
Fix bug in bitwarden-unlock when not using bitwarden-automatic-unlock

### DIFF
--- a/bitwarden.el
+++ b/bitwarden.el
@@ -4,7 +4,7 @@
 
 ;; Author: Sean Farley
 ;; URL: https://github.com/seanfarley/emacs-bitwarden
-;; Version: 0.1.1
+;; Version: 0.1.2
 ;; Created: 2018-09-04
 ;; Package-Requires: ((emacs "24.4"))
 ;; Keywords: extensions processes bw bitwarden

--- a/bitwarden.el
+++ b/bitwarden.el
@@ -198,8 +198,9 @@ since that could be set yet could be expired or incorrect.
 If run interactively PRINT-MESSAGE gets set and messages are
 printed to minibuffer."
   (interactive "p")
-  (let ((pass (when bitwarden-automatic-unlock
-                (funcall bitwarden-automatic-unlock))))
+  (let ((pass (if bitwarden-automatic-unlock
+                  (funcall bitwarden-automatic-unlock)
+                "")))
     (bitwarden--raw-unlock (list "unlock" pass) print-message)))
 
 ;;;###autoload


### PR DESCRIPTION
make-process fails when passed a nil, which would happen when not using bitwarden-automatic-unlock because pass was defined via a when form.

Using an if instead so that pass will be the empty string if bitwarden-automatic-unlock is not defined. This will not affect unlock behaviour if bitwarden-automatic-unlock has been defined.