### PR TITLE
Add support for bitwarden API key based login 

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,18 +29,20 @@ the [[file:bitwarden.el::(defcustom%20bitwarden-automatic-unlock%20nil][bitwarde
         (plist-get entry :secret)))
 #+end_src
 
-If your bitwarden store is kept on bitwarden servers (as opposed to hosting your own server), you
-may find that the above approach does not work and gives a =Symbol’s value as variable is void:
-print-message= error. This may be due to a recent change in bitwarden login procedures which require
-the use of an API application key. To check if this is indeed the problem try logging in from the
-command line with =bw login [username] 'password'= if you are prompted for an API key then the
-following instructions may resolve your problem.
+If your bitwarden store is kept on bitwarden servers (as opposed to hosting your
+own server), you may find that the above approach does not work and gives a
+=Symbol’s value as variable is void: print-message= error. This may be due to a
+recent change in bitwarden login procedures which require the use of an API
+application key. To check if this is indeed the problem try logging in from the
+command line with =bw login [username] 'password'= if you are prompted for an API
+key then the following instructions may resolve your problem.
 
-Login to the [[https://vault.bitwarden.com][bitwarden web interface]], login to your vault, go to the
-=settings= tab and scroll down to the API Key section. Follow the instructions to setup your API
-key. You will need both your =client_id= and your =client_secret=. Then add to your init.el configuration
-two functions =bitwarden-api-client-id= and =bitwarden-api-client-secret= which have the same specification format as =bitwarden-automatic-unlock=.
-Here is an example emacs configuration,
+Login to the [[https://vault.bitwarden.com][bitwarden web interface]], login to your vault, go to the =settings=
+tab and scroll down to the API Key section. Follow the instructions to setup
+your API key. You will need both your =client_id= and your =client_secret=. Then add
+to your init.el configuration two functions =bitwarden-api-client-id= and
+=bitwarden-api-client-secret= which have the same specification format as
+=bitwarden-automatic-unlock=. Here is an example emacs configuration,
 
 #+begin_src emacs-lisp
 (setq bitwarden-api-secret-key

--- a/README.org
+++ b/README.org
@@ -33,7 +33,7 @@ If your bitwarden store is kept on bitwarden servers (as opposed to hosting your
 may find that the above approach does not work and gives a =Symbol’s value as variable is void:
 print-message= error. This may be due to a recent change in bitwarden login procedures which require
 the use of an API application key. To check if this is indeed the problem try logging in from the
-command line with =bw login [username] 'password= if you are prompted for an API key then the
+command line with =bw login [username] 'password'= if you are prompted for an API key then the
 following instructions may resolve your problem.
 
 Login to the [[https://vault.bitwarden.com][bitwarden web interface]], login to your vault, go to the

--- a/README.org
+++ b/README.org
@@ -36,7 +36,7 @@ the use of an API application key. To check if this is indeed the problem try lo
 command line with =bw login [username] 'password= if you are prompted for an API key then the
 following instructions may resolve your problem.
 
-Login to the [bitwarden web interface](https://vault.bitwarden.com), login to your vault, go to the
+Login to the [[https://vault.bitwarden.com][bitwarden web interface]], login to your vault, go to the
 =settings= tab and scroll down to the API Key section. Follow the instructions to setup your API
 key. You will need both your =client_id= and your =client_secret=. Then add to your init.el configuration
 two functions =bitwarden-api-client-id= and =bitwarden-api-client-secret= which have the same specification format as =bitwarden-automatic-unlock=.
@@ -49,11 +49,13 @@ For example, here is the relevant section from my configuration.
       (plist-get (car (auth-source-search :host "bitwarden.id"))
                  :secret))
 #+end_src
+
 Note that these query two lines in my =authinfo.gpg= that have the form:
-#+BEGIN_QUOTE
+
+#+begin_quote
 machine bitwarden.key login YYY password XXX
 machine bitwarden.id login YYY password XXX
-#+END_QUOTE
+#+end_quote
 
 ** auth-source
 

--- a/README.org
+++ b/README.org
@@ -29,6 +29,32 @@ the [[file:bitwarden.el::(defcustom%20bitwarden-automatic-unlock%20nil][bitwarde
         (plist-get entry :secret)))
 #+end_src
 
+If your bitwarden store is kept on bitwarden servers (as opposed to hosting your own server), you
+may find that the above approach does not work and gives a =Symbol’s value as variable is void:
+print-message= error. This may be due to a recent change in bitwarden login procedures which require
+the use of an API application key. To check if this is indeed the problem try logging in from the
+command line with =bw login [username] 'password= if you are prompted for an API key then the
+following instructions may resolve your problem.
+
+Login to the [bitwarden web interface](https://vault.bitwarden.com), login to your vault, go to the
+=settings= tab and scroll down to the API Key section. Follow the instructions to setup your API
+key. You will need both your =client_id= and your =client_secret=. Then add to your init.el configuration
+two functions =bitwarden-api-client-id= and =bitwarden-api-client-secret= which have the same specification format as =bitwarden-automatic-unlock=.
+For example, here is the relevant section from my configuration.
+#+begin_src emacs-lisp
+  (setq bitwarden-api-secret-key
+	(plist-get (car (auth-source-search :host "bitwarden.key"))
+		   :secret))
+  (setq bitwarden-api-client-id
+	(plist-get (car (auth-source-search :host "bitwarden.id"))
+		   :secret))
+#+end_src
+Note that these query two lines in my =authinfo.gpg= that have the form:
+#+BEGIN_QUOTE
+machine bitwarden.key login YYY password XXX
+machine bitwarden.id login YYY password XXX
+#+END_QUOTE
+
 ** auth-source
 
 There is read-only support for auth-source as well. You can run

--- a/README.org
+++ b/README.org
@@ -42,12 +42,12 @@ key. You will need both your =client_id= and your =client_secret=. Then add to y
 two functions =bitwarden-api-client-id= and =bitwarden-api-client-secret= which have the same specification format as =bitwarden-automatic-unlock=.
 For example, here is the relevant section from my configuration.
 #+begin_src emacs-lisp
-  (setq bitwarden-api-secret-key
-	(plist-get (car (auth-source-search :host "bitwarden.key"))
-		   :secret))
-  (setq bitwarden-api-client-id
-	(plist-get (car (auth-source-search :host "bitwarden.id"))
-		   :secret))
+(setq bitwarden-api-secret-key
+      (plist-get (car (auth-source-search :host "bitwarden.key"))
+                 :secret))
+(setq bitwarden-api-client-id
+      (plist-get (car (auth-source-search :host "bitwarden.id"))
+                 :secret))
 #+end_src
 Note that these query two lines in my =authinfo.gpg= that have the form:
 #+BEGIN_QUOTE

--- a/README.org
+++ b/README.org
@@ -40,7 +40,8 @@ Login to the [[https://vault.bitwarden.com][bitwarden web interface]], login to 
 =settings= tab and scroll down to the API Key section. Follow the instructions to setup your API
 key. You will need both your =client_id= and your =client_secret=. Then add to your init.el configuration
 two functions =bitwarden-api-client-id= and =bitwarden-api-client-secret= which have the same specification format as =bitwarden-automatic-unlock=.
-For example, here is the relevant section from my configuration.
+Here is an example emacs configuration,
+
 #+begin_src emacs-lisp
 (setq bitwarden-api-secret-key
       (plist-get (car (auth-source-search :host "bitwarden.key"))
@@ -50,7 +51,7 @@ For example, here is the relevant section from my configuration.
                  :secret))
 #+end_src
 
-Note that these query two lines in my =authinfo.gpg= that have the form:
+For those using =authinfo.gpg=, these two lines have the form,
 
 #+begin_quote
 machine bitwarden.key login YYY password XXX

--- a/bitwarden.el
+++ b/bitwarden.el
@@ -105,14 +105,14 @@ Set this to a lambda that will evaluate to a string (the API client id)."
   "Check if `bitwarden-user' is logged in.
 Returns nil if not logged in."
   (let* ((ret (apply #'bitwarden--raw-runcmd "login" '("--check")))
-	 (exit-code (nth 0 ret)))
+         (exit-code (nth 0 ret)))
     (eq exit-code 0)))
 
 (defun bitwarden-unlocked-p ()
   "Check if `bitwarden-user' is loged in.
 Returns nil if not unlocked."
   (let* ((ret (apply #'bitwarden--raw-runcmd "unlock" '("--check")))
-	 (exit-code (nth 0 ret)))
+         (exit-code (nth 0 ret)))
     (eq exit-code 0)))
 
 (defun bitwarden--raw-runcmd (cmd &rest args)
@@ -240,9 +240,9 @@ printed to minibuffer."
   (interactive "p")
   (if (and bitwarden-api-client-id bitwarden-api-secret-key)
       (progn
-	(setenv "BW_CLIENTID" (funcall bitwarden-api-client-id))
-	(setenv "BW_CLIENTSECRET" (funcall bitwarden-api-secret-key))
-	(bitwarden--raw-unlock (list "login") print-message))
+        (setenv "BW_CLIENTID" (funcall bitwarden-api-client-id))
+        (setenv "BW_CLIENTSECRET" (funcall bitwarden-api-secret-key))
+        (bitwarden--raw-unlock (list "login") print-message))
     (unless bitwarden-user
       (setq bitwarden-user (read-string "Bitwarden email: ")))
     (let ((pass (when bitwarden-automatic-unlock


### PR DESCRIPTION
Fixes #10 

This adds two custom variables `bitwarden-api-secret-key` and `bitwarden-api-client-id` that have the same interface as the existing `bitwarden-automatic-unlock`. These are optional but used as the prefered login method if non-nil. I have updated the readme providing guidance on how to obtain an API key and client_id and emphasizing that this approach only need to be used if users are storing their valult on bitwarden servers. 