### PR TITLE
readme: Update Bitwarden CLI reference url

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,7 +6,7 @@ A Bitwarden command wrapper for Emacs.
 
 ** Installation
 
-To use this package you will need the [[https://github.com/bitwarden/cli][Bitwarden CLI]].
+To use this package you will need the [[https://github.com/bitwarden/clients/tree/master/apps/cli][Bitwarden CLI]].
 
 ** Automatic unlock
 


### PR DESCRIPTION
The [current](https://github.com/bitwarden/cli) reference of the Bitwarden CLI links to an archived repository.

The Bitwarden CLI repository has moved to: https://github.com/bitwarden/clients/tree/master/apps/cli.