### PR TITLE
Invalidate Session on bitwarden-lock

### DIFF
--- a/bitwarden.el
+++ b/bitwarden.el
@@ -253,8 +253,8 @@ printed to minibuffer."
 (defun bitwarden-lock ()
   "Lock the bw vault.  Does not ask for confirmation."
   (interactive)
-  (when (bitwarden-unlocked-p)
-    (setenv "BW_SESSION" nil)))
+  (bitwarden-runcmd "lock")
+  (setenv "BW_SESSION" nil))
 
 (defun bitwarden-logout ()
   "Log out bw.  Does not ask for confirmation."


### PR DESCRIPTION
The Code before this just set the env variable `BW_SESSION` to nil. This deletes the session key but leaves it valid, so it can basically act as a master key.

This commit fixes this by actually calling the `bw lock` command and therefore invalidating the session key and setting the variable `BW_SESSION` to nil no matter if the vault is still unlocked. This way the function can get called multiple times and the vault stays locked and the env variable stays empty even when the vault was locked by i.e. another terminal

Note vterm keeps the env variable until it is exited (not just minimized).