### PR TITLE
Fix string-match arm in proc filter

### DIFF
--- a/bitwarden.el
+++ b/bitwarden.el
@@ -157,7 +157,7 @@ If PRINT-MESSAGE is set then messages are printed to minibuffer."
       (process-send-string proc (concat bitwarden-user "\n"))))
 
   ;; read master password
-  (when (string-match "^? Master password:" string)
+  (when (string-match "^? Master password:.*" string)
     (process-send-string
      proc (concat (read-passwd "Bitwarden master password: ") "\n")))
 


### PR DESCRIPTION
When using bw cli my out put is `? Master password: [input is hidden]` followed by some random characters insted of just `? Master password:`.

This commit makes the string-match work with the output of my version of `bw` by also beeing compatible with the old format.

May be too broad though