### PR TITLE
Add get-info-by-id for programmatic access

### DIFF
--- a/bitwarden.el
+++ b/bitwarden.el
@@ -368,6 +368,17 @@ Returns a vector of hashtables of the results."
              (json (json-read-from-string result)))
            json))))
 
+;;;###autoload
+(defun bitwarden-get-info-by-id (id)
+  "The id can be found using the bitwarden CLI. For example: bw list items --pretty.
+To access the account password: `(gethash \"password\" (gethash \"login\" ))'"
+  (let* ((result (bitwarden--handle-message (bitwarden--auto-cmd (list "get" "item" id)))))
+        (when result
+      (let* ((json-object-type 'hash-table)
+             (json-key-type 'string)
+             (json (json-read-from-string result)))
+         (json-read-from-string result)))))
+
 (defun bitwarden-folders ()
   "List bitwarden folders."
   (let* ((ret (bitwarden--auto-cmd (list "list" "folders")))


### PR DESCRIPTION
I'm trying to move as many secrets as I can into Bitwarden. With `get-password-by-id`, I can retrieve login info programmatically.  I wasn't sure of the easiest way to find the ID through this wrapper. I can see it when hovering over items in `*-list-all` but not sure how to get it out of there.

If it doesn't feel like this belongs, feel free to close this PR and it'll live on happily in my .init :)